### PR TITLE
With penalty seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
-# ALternative-scoring
+# # ALternative-scoring
 /Alternative Scoring – Gliding, FOR NATIONAL, CONTINENTAL, AND WORLD GLIDING CHAMPIONSHIPS CLASS D (gliders) Including Class DM (motorgliders). 7 February 2022
+
+## **Read Me - Alternative scoring with penalty seconds**
+Final program debugged version 12/30/2022
+The script "IGC_Annex_A_scoring_2023_with_penalty" enables the scoring of gliding competitions according to the calculation formula published in the document "Alternative Scoring - Gliding" dated February 7, 2022.
+[https://www.fai.org/sites/default/files/altscoring.pdf](https://www.fai.org/sites/default/files/altscoring.pdf)
+Without entering parameters in the window "Properties of the competition day" - line Pilots[i].Tag checks the flights in the usual way. In the Results, for the purpose of continuous calculation control, the display of Sp0, Spm and k parameters has been added.
+Sp0 – Highest Provisional Score (SP) of the Day
+Spm – Median Provisional Score (SP) of the Day, excluding competitors with SP = 0.
+k – number of competitors whose scores were used to calculate Spm. The number of competitors whose score is not equal to 0.
+## **PEV**
+After entering the PEVWaitTime parameters, PEVStartWindow checks the correctness of the departure performed according to paragraph 7.4.2 b The PEV start stated in document Annex A to Section 3 – Gliding.
+[https://www.fai.org/sites/default/files/sc3a_2022.pdf](https://www.fai.org/sites/default/files/sc3a_2022.pdf)
+The number of PEV starts in the program is limited to 3. The program ignores further pressing of the PEV marker within 30 seconds. This time can be set in the constants of program.
+PevStartTimeBuffer = 30;
+If "AllUserWrng" in "DayTag" is set to 0, it will only display a start-message in the pilot warnings in case of a wrong start. When set to 1, it will display all and correct departures as well.
+## **Interpolation of starting speed according to DAEC SWO 7.3.5**
+Enter "MaxStSpd2=130" in DayTag to get interpolation and user alerts if average initial speed is greater than 130 km/h
+## **Penalty second**s
+The program can evaluate the start altitude, start groundspeed and height difference between start and arrival and the exceedance of these values will be rated with seconds added to the competitor's flight time. It will then reduce the speed of the competitor. Vo, T0 parameters for scoring are calculated only after these corrections.
+This should allow the organizer to set the start altitude, for example, 300 m below the predicted altitude of the cloud bases and to set the preferred altitude on arrival. The aim is to increase safety before start and upon arrival.
+The parameter settings are displayed in the results for review.
+The output of the evaluation is in the pilot's warning window. I assume copying the output to the "Comments" window so that it can be seen in the results.
+The following penalty values are set in the constants of program (values can be changed):
+GPS ground speed - 5 seconds per 1 km/h (taken from GP).
+Altitude AMSL - 2 seconds per 1 m (taken from GP).
+[https://www.fai.org/sites/default/files/sgp-rules-v9.1_0.pdf](https://www.fai.org/sites/default/files/sgp-rules-v9.1_0.pdf)
+Loss of height - 1 second per 1 m. (Taken from CPS. 6.3.6 [https://sk.gcup.eu/public/docs/rules/gcup_20150121_en.pdf](https://sk.gcup.eu/public/docs/rules/gcup_20150121_en.pdf))
+### #### Example:
+Entry into daily parameters
+PEVWaitTime=5 PEVStartWindow=8 MaxStSpd=170 MaxStAlt=1900 MaxFinishIsBelowSt=1520
+### Output warning
+Start speed higher by 18.15 km/h, penalty seconds = 91; Start height exceeded by 260 m, penalty seconds = 520; Altitude loss between departure and arrival exceeded by 238 m penalty seconds = 238; Time added to the flight 00:14:09;
+## **Other**
+Other program options were preserved from the original script IGC_Annex_A_scoring_2021, of which this script is a modification. They are described in the initial header of the script.
+
+
+# Read Me – Alternatívne bodovanie s trestnými sekundami
+Konečný súbor, odladený variant 30.12.2022
+Skript „IGC_Annex_A_scoring_2023_with_penalty“ umožňuje bodovanie plachtárskych súťaží podľa výpočtového vzorca publikovaného v dokumente športového poriadku „Alternative Scoring – Gliding“ zo dňa 7. februára 2022. 
+[https://www.fai.org/sites/default/files/altscoring.pdf](https://www.fai.org/sites/default/files/sc3a_2022.pdf)
+Bez zadania parametrov v okne „Vlastnosti súťažného dňa“ -riadok Pilots[i].Tag kontroluje lety bežným spôsobom. Vo výsledkoch pre účely priebežnej kontroly výpočtov pribudlo zobrazenie parametrov Sp0, Spm a k.
+Sp0 – Najvyššie predbežné skóre (SP) dňa
+Spm – Stredné predbežné skóre (SP) dňa, s výnimkou pretekárov s SP = 0. 
+k – počet pretekárov, ktorých skóre bolo použité pre výpočet Spm. Počet pretekárov, ktorých skóre nie je rovné 0.
+## PEV
+Po zadaní parametrov PEVWaitTime, PEVStartWindow kontroluje správnosť odletu vykonávaného podľa odseku 7.4.2 b The PEV start, dokumentu Annex A to Section 3 – Gliding.
+[https://www.fai.org/sites/default/files/sc3a_2022.pdf](https://www.fai.org/sites/default/files/sc3a_2022.pdf)
+Počet odletov PEV je v programe obmedzený na 3. Program ignoruje ďalšie stlačenie markeru PEV v priebehu 30 sekúnd. Tento čas je možné nastaviť v konštantách programu. 
+PevStartTimeBuffer = 30;
+Ak je "AllUserWrng" v “DayTag“ nastavené na 0, zobrazí vo varovaniach pilota odlet-správu len v prípade nesprávneho odletu. Pri nastavení na 1 zobrazí všetky aj správne odlety.
+### Interpolácia štartovacej rýchlosti voči zemi podľa DAEC SWO 7.3.5
+Zadajte „MaxStSpd2=130“ do DayTag, aby ste získali interpoláciu a upozornenia používateľa, ak je priemerná počiatočná rýchlosť vyššia ako 130 km/h
+## Trestné sekundy
+Program môže vyhodnocovať výšku odletu, rýchlosť odletu voči zemi a rozdiel výšky medzi odletom a príletom a prekročenie týchto nastavených hodnôt oceniť sekundami, ktoré pridá k času letu pretekára. Následne zníži rýchlosť pretekára. Parametre Vo, T0 pre bodovanie sú počítané až po týchto korekciách.
+Toto má umožniť organizátorovi nastaviť výšku odletu napríklad 300 m pod predpovedanú výšku základní a nastaviť preferovanú výšku na prílete. Cieľom je zvýšiť bezpečnosť pred odletom a na prílete.
+Nastavenia parametrov sú pre kontrolu zobrazené vo výsledkoch. 
+Výstup vyhodnotenia je do okna varovania pilota. Predpokladám kopírovanie výstupu do okna „Poznámka“, aby ho bolo vidieť vo výsledkoch.
+V konštantách programu sú nastavené nasledovné hodnoty penalizácie (hodnoty je možné meniť):
+Rýchlosť oproti zemi GPS – 5 sekúnd za 1 km/h (prevzaté z GP).
+Výška AMSL – 2 sekundy za 1 m (prevzaté z GP).
+[https://www.fai.org/sites/default/files/sgp-rules-v9.1_0.pdf](https://www.fai.org/sites/default/files/sgp-rules-v9.1_0.pdf)
+Strata výšky – 1 sekúnd za 1 m. (Prevzaté z CPS. 6.3.6 [https://sk.gcup.eu/public/docs/rules/gcup_20150121_en.pdf](https://sk.gcup.eu/public/docs/rules/gcup_20150121_en.pdf))
+### Príklad:
+#### Zadanie do denných parametrov
+PEVWaitTime=5 PEVStartWindow=8 MaxStSpd=170 MaxStAlt=1900 MaxFinishIsBelowSt=1520
+#### Výstupné varovanie
+Start speed higher by  18,15 km/h, penalty seconds =  91;  Start height exceeded by  260 m, penalty seconds =  520;  Altitude loss between departure and arrival exceeded by  238 m  penalty seconds =  238;  Time added to the flight 00:14:09; 
+Iné
+Ďalšie možnosti programu boli zachované z pôvodného skriptu IGC_Annex_A_scoring_2021, ktorého je tento skript modifikáciou. Sú opísané v úvodnej hlavičke skriptu.

--- a/Záloha/IGC_Annex_A_scoring_2023.TXT
+++ b/Záloha/IGC_Annex_A_scoring_2023.TXT
@@ -1,17 +1,9 @@
 Program IGC_Annex_A_scoring_2023;
-// Version 10.00 Date December 8, 2022 by Jan Hrncirik;
-// 
+// Version 1.00 Date November 18, 2022 by Jan Hrncirik; Debuged November 26, 2022
 //   .Alternative Scoring – Gliding, FOR NATIONAL, CONTINENTAL, AND WORLD GLIDING CHAMPIONSHIPS CLASS D (gliders) Including Class DM (motorgliders). 7 February 2022
-// 
 // Collaborate on writing scripts at Github:
 // https://github.com/naviter/seeyou_competition_scripts/
-// Version 10.00
-// Added penalty seconds for higher starting speed, for exceeding the starting height and for exceeding the permitted start-finish height loss
-// . support for penalty seconds
-// . enter "MaxStSpd=150" in DayTag for taking penalty seconds for exceeding the GPS start speed 150 km/h.
-// . enter "MaxStAlt=1700" in DayTag for exceeding the start height.
-// . enter "MaxFinishIsBelowSt=1200" in DayTag for exceeding the maximum "Finish is below start for:"
-// . example: "PEVWaitTime=10 PEVStartWindow=10 MaxStSpd=150 MaxStAlt=1700 MaxFinishIsBelowSt=1200"
+//
 // Version 9.02, Date 17.07.2022 by Andrej Kolar
 //   . Reintroduced Hmin parameter to be able to calculate results for Handicaps between 80-130
 // Version 9.01, Date 08.07.2022 by Andrej Kolar
@@ -62,7 +54,7 @@ Program IGC_Annex_A_scoring_2023;
 
 const UseHandicaps = 2;   // set to: 0 to disable handicapping, 1 to use handicaps, 2 is auto (handicaps only for club and multi-seat)
       PevStartTimeBuffer = 30; // PEV which is less than PevStartTimeBuffer seconds later than last PEV will be ignored and not counted
-      UsePenaltySeconds = 1; //If set to 1, it will use penalty seconds, otherwise it will only give warnings   
+   
 var
   Dm, D1,
   Dt, n1, n2, n3, n4, N, D0, Vo, T0, Hmin,

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -1,4 +1,5 @@
 Program IGC_Annex_A_scoring_2023_with_penalty;
+//Final version December 30, 2022 by Jan Hrncirik
 // Version 10.00 Date December 8, 2022 by Jan Hrncirik;
 // 
 //   .Alternative Scoring – Gliding, FOR NATIONAL, CONTINENTAL, AND WORLD GLIDING CHAMPIONSHIPS CLASS D (gliders) Including Class DM (motorgliders). 7 February 2022

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -316,17 +316,18 @@ begin
 		 DStSpd := PilotStartSpeed - MaxStSpd;
 		 DPStAlt := PilotStartAlt - MaxStAlt;
      DFinishIsBelowSt := MaxFinishIsBelowSt - (PilotStartAlt - Pilots[i].finishAlt);
-           
+
+     Pilots[i].Warning := Pilots[i].Warning + #13;      
      if DStSpd > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + DStspd * PStSpd;
-         Pilots[i].Warning := Pilots[i].Warning  + ' DStSpd = ' + FormatFloat('# ###',DStSpd) + #13;
+         Pilots[i].Warning := Pilots[i].Warning  + ' DStSpd = ' + FormatFloat('# ###',DStSpd) + #10;
        end;
     
      if DPStAlt > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + DPStAlt * PStAlt;
-         Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + FormatFloat('# ###',DPStAlt) + #13;
+         Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + FormatFloat('# ###',DPStAlt) + #10;
        end;
      
      if DFinishIsBelowSt > MaxFinishIsBelowSt then
@@ -334,6 +335,8 @@ begin
          Pilots[i].finish := Pilots[i].finish + Int(DFinishIsBelowSt * PFinishIsBelowSt);
          Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + FormatFloat('# ###',DFinishIsBelowSt) + #13;
        end;   
+
+     Pilots[i].Warning := Pilots[i].Warning + #13 + FormatFloat('# ###',DStSpd) + #10 +  FormatFloat('# ###',DPStAlt) + #10 + FormatFloat('# ###',DFinishIsBelowSt) + #13;
      
      T0 := Pilots[i].finish - Pilots[i].start;
      if (AAT = true) and (T0 < Task.TaskTime) Then T0 := Task.TaskTime;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -301,7 +301,7 @@ begin
             exit;
           end;
 
-          while (Vleft <= Vright) do begin // if we have something to share
+          while (Vleft <= Vright) and (Vright > 20) do begin // if we have something to share
             center:=(Vleft + Vright) div 2;
             if (item = Pilots[i].Fixes[center].Tsec) then
               begin

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -319,19 +319,19 @@ begin
      if DStSpd > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + DStspd * PStSpd;
-         Pilots[i].Warning := Pilots[i].Warning  + ' DStSpd = ' + IntToStr(DStSpd) + #10;
+         Pilots[i].Warning := Pilots[i].Warning  + ' DStSpd = ' + FormatFloat('# ###',DStSpd) + #13;
        end;
     
      if DPStAlt > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + DPStAlt * PStAlt;
-         Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + IntToStr(DPStAlt) + #10;
+         Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + FormatFloat('# ###',DPStAlt) + #13;
        end;
      
      if DFinishIsBelowSt > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + Int(DFinishIsBelowSt * PFinishIsBelowSt);
-         Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + IntToStr(DFinishIsBelowSt) + #10;
+         Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + FormatFloat('# ###',DFinishIsBelowSt) + #13;
        end;   
      
      T0 := Pilots[i].finish - Pilots[i].start;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -1,5 +1,6 @@
 Program IGC_Annex_A_scoring_2023;
-// Version 1.00 Date November 18, 2022 by Jan Hrncirik; Debuged November 26, 2022
+// Version 2.00 Date December 8, 2022 by Jan Hrncirik;
+// Version 2.00 Date December 8, 2022 by Jan Hrncirik;
 //   .Alternative Scoring – Gliding, FOR NATIONAL, CONTINENTAL, AND WORLD GLIDING CHAMPIONSHIPS CLASS D (gliders) Including Class DM (motorgliders). 7 February 2022
 // Collaborate on writing scripts at Github:
 // https://github.com/naviter/seeyou_competition_scripts/

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -492,7 +492,7 @@ end;
   Info3 := Info3 + ', Do: ' + FormatFloat('0.00',D0/1000.0) + 'km';
   Info3 := Info3 + ', Vo: ' + FormatFloat('0.00',Vo*3.6) + 'km/h';
   Info3 := Info3 + ', T0: ' + GetTimeString (Int(T0));
-  if MaxStSpd > 0 then  Info3 := Info3 + ', MaxStSpd: ' + FormatFloat('##0', MaxStSpd);
+  if MaxStSpd > 0 then  Info3 := Info3 + ', MaxStSpd: ' + FormatFloat('##0', MaxStSpd*3.6);
   if MaxStAlt > 0 then  Info3 := Info3 + ', MaxStAlt: ' + FormatFloat('# ##0', MaxStAlt);
   if MaxFinishIsBelowSt > 0 then  Info3 := Info3 + ', MaxFinishIsBelowSt : ' + FormatFloat('# ##0', MaxFinishIsBelowSt );
 

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -331,7 +331,7 @@ begin
          Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + FormatFloat('# ###',DPStAlt) + #10;
        end;
      
-     if DFinishIsBelowSt > MaxFinishIsBelowSt then
+     if DFinishIsBelowSt > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + Int(DFinishIsBelowSt * PFinishIsBelowSt);
          Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + FormatFloat('# ###',DFinishIsBelowSt) + #13;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -271,6 +271,7 @@ begin
 if UsePenaltySeconds = 1 then
 begin
   MaxStSpd := ReadDayTagParameter('MAXSTSPD', 0); 
+  MaxStSpd := MaxStSpd*1000/3600 //Conversion of km/h to m/s
   MaxStAlt := ReadDayTagParameter('MaxStAlt', 0);
   MaxFinishIsBelowSt := ReadDayTagParameter('MAXFINISHISBELOWST', 0);
   for i:=0 to GetArrayLength(Pilots)-1 do

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -8,7 +8,7 @@ Program IGC_Annex_A_scoring_2023_with_penalty;
 // Version 10.00
 // Added penalty seconds for higher starting speed, for exceeding the starting height and for exceeding the permitted start-finish height loss
 // . support for penalty seconds
-// . enter "MaxStSpd=150" in DayTag for taking penalty seconds for exceeding the GPS start speed 150 km/h.
+// . enter "MaxStSpd=150" in DayTag for taking penalty seconds for exceeding the GSP start speed 150 km/h.
 // . enter "MaxStAlt=1700" in DayTag for exceeding the start height.
 // . enter "MaxFinishIsBelowSt=1200" in DayTag for exceeding the maximum "Finish is below start for:"
 // . example: "PEVWaitTime=10 PEVStartWindow=10 MaxStSpd=150 MaxStAlt=1700 MaxFinishIsBelowSt=1200"
@@ -283,7 +283,7 @@ begin
     PilotStartAltSum :=0;
 	  if (Pilots[i].start <> -1) and (Pilots[i].finish <> -1) Then
 	    begin
-	      CountFixes := GetArrayLength(Pilots[i].Fixes;
+	      CountFixes := GetArrayLength(Pilots[i].Fixes);
         HHF := CountFixes;
         StartFixFound := true;
         while StartFixFound do
@@ -291,20 +291,22 @@ begin
           repeat
           begin
             HHF := Trunc(HHF/2);
-          until Pilots[í].start < Pilots[i].Fixes[HHF].Tsec or HHF <= 2;
-         if pilots[i].start = Pilots[i].fixes[HHF] then
+          end;
+          until (Pilots[i].start < Pilots[i].Fixes[HHF].Tsec) or (HHF <= 2);
+         if Pilots[i].start = Pilots[i].fixes[HHF].Tsec then
           begin
            StartFixFound := false;
            PilotStartAlt := Pilots[i].Fixes[HHF].AltQnh;
-           PilotStartSpeed := Pilots[i].Fixes[HHF].GPS;
+           PilotStartSpeed := Pilots[i].Fixes[HHF].Gsp;
           end;       
-         if pilots[i].start > Pilots[i].fixes[HHF+1] then
+         if pilots[i].start > Pilots[i].fixes[HHF+1].Tsec then
           begin
            StartFixFound := false;
            PilotStartAlt := (Pilots[i].Fixes[HHF].AltQnh + Pilots[i].Fixes[HHF+1].AltQnh)/2;
-           PilotStartSpeed := (Pilots[i].Fixes[HHF].GPS + Pilots[i].Fixes[HHF+1].GPS)/2;
+           PilotStartSpeed := (Pilots[i].Fixes[HHF].Gsp + Pilots[i].Fixes[HHF+1].Gsp)/2;
+          end 
           else
-           HHF := 3*HHF / 2;
+           HHF := Trunc(3*HHF / 2);
           end;  
          if HHF < 3 then StartFixFound := false;     
         end;
@@ -502,7 +504,7 @@ end;
 
   for i:=0 to GetArrayLength(Pilots)-1 do
   begin
-    Pilots[i].Warning := ''; 
+    //Pilots[i].Warning := ''; 
     if (Pilots[i].start > 0) Then
     begin	
       if (PEVWaitTime>0) and (PEVStartWindow>0) then   
@@ -534,12 +536,12 @@ end;
           else
             if (Pilots[i].start>=Task.NoStartBeforeTime) and (AllUserWrng>=1) Then
               PEVWarning:=PevWarning+' Start='+GetTimestring(Trunc(Pilots[i].Start))+' OK'+', '; 
-          Pilots[i].Warning:= PevWarning;
+          //Pilots[i].Warning:= PevWarning;
         end
         else
            PEVWarning:='PEV not found!'+', ';
 
-        Pilots[i].Warning:= PevWarning;   
+        //Pilots[i].Warning:= PevWarning;   
       end;
       if Pilots[i].start<Task.NoStartBeforeTime then Pilots[i].Warning :=Pilots[i].Warning+' Start='+GetTimestring(Trunc(Pilots[i].start))+' before gate opens!'+', ';     
     end;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -75,7 +75,7 @@ var
   
   PmaxDistance, PmaxTime : double;
 
-  MaxStAlt, MaxFinishIsBelowSt, DStSpd, DPStAlt, DFinishIsBelowSt : double;
+  MaxStSpd, MaxStAlt, MaxFinishIsBelowSt, DStSpd, DPStAlt, DFinishIsBelowSt : double;
   
   i,j,k : integer;
   PevWaitTime,PEVStartWindow,AllUserWrng, PilotStartInterval, PilotStartTime, PilotPEVStartTime,StartTimeBuffer,MaxStartSpeed : Integer;
@@ -270,9 +270,9 @@ begin
 // Correction of speed and flight time with penalty seconds
 if UsePenaltySeconds = 1 then
 begin
-  MaxStSpd := ReadDayTagParameter ('MAXSTSPD', 0); 
-  MaxStAlt := ReadDayTagParameter ('MaxStAlt', 0);
-  MaxFinishIsBelowSt := ReadDayTagParameter ('MAXFINISHISBELOWST', 0);
+  MaxStSpd := ReadDayTagParameter('MAXSTSPD', 0); 
+  MaxStAlt := ReadDayTagParameter('MaxStAlt', 0);
+  MaxFinishIsBelowSt := ReadDayTagParameter('MAXFINISHISBELOWST', 0);
   for i:=0 to GetArrayLength(Pilots)-1 do
   begin
     DStSpd := 0;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -319,19 +319,19 @@ begin
      if DStSpd > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + DStspd * PStSpd;
-         Pilots[i].Warning := Pilots[i].Warning  + ' DStSpd = ' + IntToStr(DStSpd);
+         Pilots[i].Warning := Pilots[i].Warning  + ' DStSpd = ' + IntToStr(DStSpd) + #10;
        end;
     
      if DPStAlt > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + DPStAlt * PStAlt;
-         Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + IntToStr(DPStAlt);
+         Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + IntToStr(DPStAlt) + #10;
        end;
      
      if DFinishIsBelowSt > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + Int(DFinishIsBelowSt * PFinishIsBelowSt);
-         Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + IntToStr(DFinishIsBelowSt);
+         Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + IntToStr(DFinishIsBelowSt) + #10;
        end;   
      
      T0 := Pilots[i].finish - Pilots[i].start;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -60,9 +60,12 @@ Program IGC_Annex_A_scoring_2023;
 // Version 3.20
 //   . added warnings when Exit 
 
-const UseHandicaps = 2;   // set to: 0 to disable handicapping, 1 to use handicaps, 2 is auto (handicaps only for club and multi-seat)
-      PevStartTimeBuffer = 30; // PEV which is less than PevStartTimeBuffer seconds later than last PEV will be ignored and not counted
-      UsePenaltySeconds = 1; //If set to 1, it will use penalty seconds, otherwise it will only give warnings   
+const UseHandicaps = 2;         // set to: 0 to disable handicapping, 1 to use handicaps, 2 is auto (handicaps only for club and multi-seat)
+      PevStartTimeBuffer = 30;  // PEV which is less than PevStartTimeBuffer seconds later than last PEV will be ignored and not counted
+      UsePenaltySeconds = 1;    // If set to 1, it will use penalty seconds, otherwise it will only give warnings   
+      PStSpd=5                  // +5 s/ 1 km/h for exceeding the maximum starting speed
+      PStAlt=2                  // +2 s/ 1 m for exceeding the maximum start altitud
+      PMaxFinishIsBelowSt=1     // +2 s/ 1 m for exceeding the maximum "Finish is below start for"
 var
   Dm, D1,
   Dt, n1, n2, n3, n4, N, D0, Vo, T0, Hmin,

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -280,7 +280,8 @@ begin
     PilotStartSpeed := 0;
 	  PilotStartSpeedSum := 0;	
     PilotStartAlt := 0;
-    PilotStartAltSum :=0;
+    PilotStartAltSum := 0;
+    Vresult:= 0;
 	  if (Pilots[i].start <> -1) and (Pilots[i].finish <> -1) Then
 	    begin
 	      //CountFixes := GetArrayLength(Pilots[i].Fixes);
@@ -298,7 +299,7 @@ begin
             Info1 := 'element out of scope item = ' + IntToStr(item);
             exit;
           end;
-          
+
           while (Vleft <= Vright) do begin // if we have something to share
             center:=(Vleft + Vright) div 2;
             if (item = Pilots[i].Fixes[center].Tsec) then
@@ -566,4 +567,5 @@ end;
       if Pilots[i].start<Task.NoStartBeforeTime then Pilots[i].Warning :=Pilots[i].Warning+' Start='+GetTimestring(Trunc(Pilots[i].start))+' before gate opens!'+', ';     
     end;
   end;
+end;  
 end.

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -71,13 +71,13 @@ var
   Dt, n1, n2, n3, n4, N, D0, Vo, T0, Hmin,
   Pm, Pdm, Pvm, Pn, F, Fcr, Sp0, Spm, Day: Double;  
 
-  D, H, Dh, M, T, Dc, Pd, V, Vh, Pv, Sp, S, CountFixes, HHF  : double;
+  D, H, Dh, M, T, Dc, Pd, V, Vh, Pv, Sp, S : double;
   
   PmaxDistance, PmaxTime : double;
 
   MaxStSpd, MaxStAlt, MaxFinishIsBelowSt, DStSpd, DPStAlt, DFinishIsBelowSt : double;
   
-  i,j,k, CountFixes, HHF, center, Vleft, Vright, Vresult, item : integer;
+  i,j,k, CountFixes, HHF, center, Vleft, Vright, Vresult, item  : integer;
   PevWaitTime,PEVStartWindow,AllUserWrng, PilotStartInterval, PilotStartTime, PilotPEVStartTime,StartTimeBuffer,MaxStartSpeed : Integer;
   AAT : boolean;
   Auto_Hcaps_on, StartFixFound : boolean;
@@ -289,11 +289,10 @@ begin
 
         // binary searches Begin
         begin
-          item := Pilots[i].start;
-          anarray := Pilots[i].Fixes;
+          item := Trunc(Pilots[i].start);
           Vleft:=0;
-          Vright:=length(anarray) - 1;
-          if ((item < anarray[Vleft]) or (item > anarray[Vright])) then // prvek mimo rozsah
+          Vright:= GetArrayLength(Pilots[i].Fixes) - 1;
+          if ((item < Pilots[i].Fixes[Vleft].Tsec) or (item > Pilots[i].Fixes[Vright].Tsec)) then // element out of scope
           begin
             Vresult:=-1;
             Info1 := 'element out of scope item = ' + IntToStr(item);
@@ -301,22 +300,22 @@ begin
           end;
           while (Vleft <= Vright) do begin // if we have something to share
             center:=(Vleft + Vright) div 2;
-            if (item = anarray[center].Tsec) then
+            if (item = Pilots[i].Fixes[center].Tsec) then
               begin
-                PilotStartAlt := anarray[center].AltQnh;
-                PilotStartSpeed := anarray[center].Gsp;
+                PilotStartAlt := Pilots[i].Fixes[center].AltQnh;
+                PilotStartSpeed := Pilots[i].Fixes[center].Gsp;
                 Vresult:=center; // found
                 Break; // Ending the loop while
             end
             else
-            if (item < anarray[center].Tsec) then
+            if (item < Pilots[i].Fixes[center].Tsec) then
               Vright:=center - 1 // throw away the Vright half
             else
               Vleft:=center + 1; // discard the Vleft half
-              if (item < anarray[center+1].Tsec) then
+              if (item < Pilots[i].Fixes[center+1].Tsec) then
                 begin
-                  PilotStartAlt := (anarray[center].AltQnh + anarray[center+1].AltQnh) div 2;
-                  PilotStartSpeed := (anarray[center].Gsp + anarray[center+1].Gsp;) div 2
+                  PilotStartAlt := (Pilots[i].Fixes[center].AltQnh + Pilots[i].Fixes[center+1].AltQnh) / 2;
+                  PilotStartSpeed := (Pilots[i].Fixes[center].Gsp + Pilots[i].Fixes[center+1].Gsp) / 2;
                   Vresult:=center; // found
                   Break; // Ending the loop while
                 end;
@@ -326,7 +325,7 @@ begin
         end;
         If Vresult = -1 then
           begin
-            Info1 := 'Start not found!';
+            Info1 := 'Start not found! Vresult = -1';
             exit;
           end;  
         // binary searches End

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -63,9 +63,9 @@ Program IGC_Annex_A_scoring_2023_with_penalty;
 const UseHandicaps = 2;         // set to: 0 to disable handicapping, 1 to use handicaps, 2 is auto (handicaps only for club and multi-seat)
       PevStartTimeBuffer = 30;  // PEV which is less than PevStartTimeBuffer seconds later than last PEV will be ignored and not counted
       UsePenaltySeconds = 1;    // If set to 1, it will use penalty seconds, otherwise it will only give warnings   
-      PStSpd=5                  // +5 s/ 1 km/h for exceeding the maximum starting speed
-      PStAlt=2                  // +2 s/ 1 m for exceeding the maximum start altitud
-      PFinishIsBelowSt=1     // +2 s/ 1 m for exceeding the maximum "Finish is below start for"
+      PStSpd=5;                  // +5 s/ 1 km/h for exceeding the maximum starting speed
+      PStAlt=2;                  // +2 s/ 1 m for exceeding the maximum start altitud
+      PFinishIsBelowSt=1;     // +2 s/ 1 m for exceeding the maximum "Finish is below start for"
 var
   Dm, D1,
   Dt, n1, n2, n3, n4, N, D0, Vo, T0, Hmin,

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -71,6 +71,8 @@ var
   D, H, Dh, M, T, Dc, Pd, V, Vh, Pv, Sp, S  : double;
   
   PmaxDistance, PmaxTime : double;
+
+  MaxStAlt, MaxFinishIsBelowSt : double;
   
   i,j,k : integer;
   PevWaitTime,PEVStartWindow,AllUserWrng, PilotStartInterval, PilotStartTime, PilotPEVStartTime,StartTimeBuffer,MaxStartSpeed : Integer;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -65,7 +65,7 @@ const UseHandicaps = 2;         // set to: 0 to disable handicapping, 1 to use h
       UsePenaltySeconds = 1;    // If set to 1, it will use penalty seconds, otherwise it will only give warnings   
       PStSpd=5;                  // +5 s/ 1 km/h for exceeding the maximum starting speed
       PStAlt=2;                  // +2 s/ 1 m for exceeding the maximum start altitud
-      PFinishIsBelowSt=1;     // +2 s/ 1 m for exceeding the maximum "Finish is below start for"
+      PFinishIsBelowSt=1;     // +1 s/ 1 m for exceeding the maximum "Finish is below start for"
 var
   Dm, D1,
   Dt, n1, n2, n3, n4, N, D0, Vo, T0, Hmin,

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -25,7 +25,7 @@ Program IGC_Annex_A_scoring_2023_with_penalty;
 //   . if "AllUserWrng" in DayTag is set to 0 user warning with PEVs is only shown if penalty should be necessary otherwise PEVs are displayed
 //   . buffer zone as a script parameter
 //   . added start speed interpolation according to DAEC SWO 7.3.5
-//   . enter "MaxStSpd=130" in DayTag to have interpolation and userwarnings if average start speed is higher than 130km/h 
+//   . enter "MaxStSpd=130" in DayTag to have interpolation and userwarnings if average start speed is higher than 130 km/h 
 // Version 8.01, Date 20.04.2021
 //   . added ReadDayTagParameter() function to read any DayTag parameter
 //   . parameters in DayTag now have to be separated by space (only)
@@ -518,8 +518,8 @@ end;
   Info3 := Info3 +' N: ' + IntToStr(Round(N));
   Info3 := Info3 + ', n1: ' + IntToStr(Round(n1));
   Info3 := Info3 + ', n3: ' + IntToStr(Round(n3));
-  Info3 := Info3 + ', Do: ' + FormatFloat('0.00',D0/1000.0) + 'km';
-  Info3 := Info3 + ', Vo: ' + FormatFloat('0.00',Vo*3.6) + 'km/h';
+  Info3 := Info3 + ', Do: ' + FormatFloat('0.00',D0/1000.0) + ' km';
+  Info3 := Info3 + ', Vo: ' + FormatFloat('0.00',Vo*3.6) + ' km/h';
   Info3 := Info3 + ', T0: ' + GetTimeString (Int(T0));
   if MaxStSpd > 0 then  Info3 := Info3 + ', MaxStSpd: ' + FormatFloat('##0', MaxStSpd*3.6);
   if MaxStAlt > 0 then  Info3 := Info3 + ', MaxStAlt: ' + FormatFloat('# ##0', MaxStAlt);

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -271,7 +271,7 @@ begin
 if UsePenaltySeconds = 1 then
 begin
   MaxStSpd := ReadDayTagParameter('MAXSTSPD', 0); 
-  MaxStSpd := MaxStSpd*1000/3600 //Conversion of km/h to m/s
+  MaxStSpd := MaxStSpd*1000/3600; //Conversion of km/h to m/s
   MaxStAlt := ReadDayTagParameter('MaxStAlt', 0);
   MaxFinishIsBelowSt := ReadDayTagParameter('MAXFINISHISBELOWST', 0);
   for i:=0 to GetArrayLength(Pilots)-1 do

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -316,7 +316,7 @@ begin
 		 DStSpd := PilotStartSpeed - MaxStSpd;
      DStSpd := DStSpd * 3.6; // m/s to km/h
 		 DPStAlt := PilotStartAlt - MaxStAlt;
-     DFinishIsBelowSt := MaxFinishIsBelowSt - (PilotStartAlt - Pilots[i].finishAlt);
+     DFinishIsBelowSt := (PilotStartAlt - Pilots[i].finishAlt) - MaxFinishIsBelowSt;
 
      Pilots[i].Warning := Pilots[i].Warning + #13;      
      if DStSpd > 0 then

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -307,7 +307,7 @@ begin
           end 
           else
            HHF := CountFixes + HHF;
-           if Trunc(HHF/2) > CountFixes-1 then StartFixFound := false;
+           if Trunc(HHF/2) > CountFixes-1 tHHF := CountFixes + HHF;hen StartFixFound := false;
           end;  
          if HHF < 3 then StartFixFound := false;     
         end;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -278,7 +278,7 @@ begin
     DStSpd := 0;
     DPStAlt := 0;
     DFinishIsBelowSt := 0;
-    if Pilot[i].start and Pilot[i].finish
+    if (Pilots[i].start <> -1) and (Pilots[i].finish <> -1) then
     begin
 	    for j := 0 to GetArrayLength(Pilots[i].Fixes)-1 do
 	    begin
@@ -286,24 +286,24 @@ begin
 		    begin
 		      DStSpd := Pilots[i].Fixes[j].Gsp - MaxStSpd;
 		      DPStAlt := Pilots[i].Fixes[j].AltQnh - MaxStAlt;
-          DFinishIsBelowSt := MaxFinishIsBelowSt -(Pilots[i].Fixes[j].AltQnh - Pilot[i].finishAlt);
+          DFinishIsBelowSt := MaxFinishIsBelowSt -(Pilots[i].Fixes[j].AltQnh - Pilots[i].finishAlt);
           break; // end the for j := loop
 	      end;
       end;
       if DStSpd > 0 then
       begin
-        Pilots[i].tfinish := Pilots[i].tfinish + Integer(DStspd * PStSpd);
-        Pilots[i].PilotTag := Pilots[i].PilotTag  + ' DStSpd = ' + IntToStr(Integer(DStSpd));
+        Pilots[i].tfinish := Pilots[i].tfinish + Int(DStspd * PStSpd);
+        Pilots[i].PilotTag := Pilots[i].PilotTag  + ' DStSpd = ' + IntToStr(Int(DStSpd));
       end;
       if DPStAlt > 0 then
       begin
-        Pilots[i].tfinish := Pilots[i].tfinish + Integer(DPStAlt * PStAlt);
-        Pilots[i].PilotTag := Pilots[i].PilotTag  + ' DPStAlt = ' + IntToStr(Integer(DPStAlt));
+        Pilots[i].tfinish := Pilots[i].tfinish + Int(DPStAlt * PStAlt);
+        Pilots[i].PilotTag := Pilots[i].PilotTag  + ' DPStAlt = ' + IntToStr(Int(DPStAlt));
       end;
       if DFinishIsBelowSt > 0 then
       begin
-        Pilots[i].tfinish := Pilots[i].tfinish + Integer(DFinishIsBelowSt * PFinishIsBelowSt);
-        Pilots[i].PilotTag := Pilots[i].PilotTag  + ' D Start-Finis alt. = ' + IntToStr(Integer(DFinishIsBelowSt));
+        Pilots[i].tfinish := Pilots[i].tfinish + Int(DFinishIsBelowSt * PFinishIsBelowSt);
+        Pilots[i].PilotTag := Pilots[i].PilotTag  + ' D Start-Finis alt. = ' + IntToStr(Int(DFinishIsBelowSt));
       end;      
     end;
   end;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -298,6 +298,7 @@ begin
             Info1 := 'element out of scope item = ' + IntToStr(item);
             exit;
           end;
+          
           while (Vleft <= Vright) do begin // if we have something to share
             center:=(Vleft + Vright) div 2;
             if (item = Pilots[i].Fixes[center].Tsec) then
@@ -312,7 +313,7 @@ begin
               Vright:=center - 1 // throw away the Vright half
             else
               Vleft:=center + 1; // discard the Vleft half
-              if (item < Pilots[i].Fixes[center+1].Tsec) then
+              if (item < Pilots[i].Fixes[Vleft].Tsec) then
                 begin
                   PilotStartAlt := (Pilots[i].Fixes[center].AltQnh + Pilots[i].Fixes[center+1].AltQnh) / 2;
                   PilotStartSpeed := (Pilots[i].Fixes[center].Gsp + Pilots[i].Fixes[center+1].Gsp) / 2;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -314,6 +314,7 @@ begin
      DFinishIsBelowSt := 0;
 	   
 		 DStSpd := PilotStartSpeed - MaxStSpd;
+     DStSpd := DStSpd * 3.6; // m/s to km/h
 		 DPStAlt := PilotStartAlt - MaxStAlt;
      DFinishIsBelowSt := MaxFinishIsBelowSt - (PilotStartAlt - Pilots[i].finishAlt);
 

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -318,7 +318,7 @@ begin
 		 DPStAlt := PilotStartAlt - MaxStAlt;
      DFinishIsBelowSt := (PilotStartAlt - Pilots[i].finishAlt) - MaxFinishIsBelowSt;
 
-     Pilots[i].Warning := Pilots[i].Warning + #13;      
+     Pilots[i].Warning := '';      
      if DStSpd > 0 then
        begin
          Pilots[i].finish := Pilots[i].finish + DStspd * PStSpd;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -329,7 +329,7 @@ begin
          Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + FormatFloat('# ###',DPStAlt) + #13;
        end;
      
-     if DFinishIsBelowSt > 0 then
+     if DFinishIsBelowSt > MaxFinishIsBelowSt then
        begin
          Pilots[i].finish := Pilots[i].finish + Int(DFinishIsBelowSt * PFinishIsBelowSt);
          Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + FormatFloat('# ###',DFinishIsBelowSt) + #13;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -293,9 +293,9 @@ begin
                PilotStartAltSum := PilotStartAltSum + Pilots[i].Fixes[j].AltQnh;
                if Pilots[i].fixes[j].Tsec = Pilots[i].start then
                begin
-                 PilotStartSpeedSum := Pilots[i].Fixes[j].Gsp;
+                 PilotStartSpeed := Pilots[i].Fixes[j].Gsp;
 		             PilotStartSpeedFixes := 0;
-                 PilotStartAltSum := Pilots[i].Fixes[j].AltQnh;
+                 PilotStartAlt := Pilots[i].Fixes[j].AltQnh;
                  break; // end the for j := loop
                end;
 	           end;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -341,7 +341,7 @@ begin
      
      T0 := Pilots[i].finish - Pilots[i].start;
      if (AAT = true) and (T0 < Task.TaskTime) Then T0 := Task.TaskTime;
-     Pilots[i].speed := Pilots[i].dis/T0;
+     if T0 > 0 then Pilots[i].speed := Pilots[i].dis/T0;
     end;
 end;
 

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -71,7 +71,7 @@ var
   Dt, n1, n2, n3, n4, N, D0, Vo, T0, Hmin,
   Pm, Pdm, Pvm, Pn, F, Fcr, Sp0, Spm, Day: Double;  
 
-  D, H, Dh, M, T, Dc, Pd, V, Vh, Pv, Sp, S  : double;
+  D, H, Dh, M, T, Dc, Pd, V, Vh, Pv, Sp, S, CountFixes, HHF  : double;
   
   PmaxDistance, PmaxTime : double;
 
@@ -291,6 +291,11 @@ begin
           repeat
           begin
             HHF := Trunc(HHF/2);
+            if HHF => CountFixes then 
+             begin
+              Info1 := 'HHF out of range HHF = ' + IntToStr(HHF) + ' CountFixes = ' + IntToStr(CountFixes);
+	            Exit;		
+             end;
           end;
           until (Pilots[i].start < Pilots[i].Fixes[HHF].Tsec) or (HHF <= 2);
          if Pilots[i].start = Pilots[i].fixes[HHF].Tsec then
@@ -302,12 +307,17 @@ begin
          if pilots[i].start > Pilots[i].fixes[HHF+1].Tsec then
           begin
            StartFixFound := false;
+           if HHF >=  CountFixes then 
+            begin
+             Info1 := 'HHF out of range HHF = ' + IntToStr(HHF) + ' CountFixes = ' + IntToStr(CountFixes);
+	           Exit;		
+            end;
            PilotStartAlt := (Pilots[i].Fixes[HHF].AltQnh + Pilots[i].Fixes[HHF+1].AltQnh)/2;
            PilotStartSpeed := (Pilots[i].Fixes[HHF].Gsp + Pilots[i].Fixes[HHF+1].Gsp)/2;
           end 
           else
            HHF := CountFixes + HHF;
-           if Trunc(HHF/2) > CountFixes-1 tHHF := CountFixes + HHF;hen StartFixFound := false;
+           if Trunc(HHF/2) > CountFixes-1 then StartFixFound := false;
           end;  
          if HHF < 3 then StartFixFound := false;     
         end;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -1,4 +1,4 @@
-Program IGC_Annex_A_scoring_2023;
+Program IGC_Annex_A_scoring_2023_with_penalty;
 // Version 10.00 Date December 8, 2022 by Jan Hrncirik;
 // 
 //   .Alternative Scoring – Gliding, FOR NATIONAL, CONTINENTAL, AND WORLD GLIDING CHAMPIONSHIPS CLASS D (gliders) Including Class DM (motorgliders). 7 February 2022

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -61,7 +61,7 @@ Program IGC_Annex_A_scoring_2023_with_penalty;
 //   . added warnings when Exit 
 
 const UseHandicaps = 2;         // set to: 0 to disable handicapping, 1 to use handicaps, 2 is auto (handicaps only for club and multi-seat)
-      PevStartTimeBuffer = 30;  // PEV which is less than PevStartTimeBuffer seconds later than last PEV will be ignored and not counted
+      PevStartTimeBuffer = 30;  // PEV which is less than PevStartTimeBuffer seconds later than last PEV will be iCountFixesgnored and not counted
       UsePenaltySeconds = 1;    // If set to 1, it will use penalty seconds, otherwise it will only give warnings   
       PStSpd=5;                  // +5 s/ 1 km/h for exceeding the maximum starting speed
       PStAlt=2;                  // +2 s/ 1 m for exceeding the maximum start altitud
@@ -77,7 +77,7 @@ var
 
   MaxStSpd, MaxStAlt, MaxFinishIsBelowSt, DStSpd, DPStAlt, DFinishIsBelowSt : double;
   
-  i,j,k, CountFixes, HHF, center, left, right, result : integer;
+  i,j,k, CountFixes, HHF, center, Vleft, Vright, Vresult, item : integer;
   PevWaitTime,PEVStartWindow,AllUserWrng, PilotStartInterval, PilotStartTime, PilotPEVStartTime,StartTimeBuffer,MaxStartSpeed : Integer;
   AAT : boolean;
   Auto_Hcaps_on, StartFixFound : boolean;
@@ -291,40 +291,40 @@ begin
         begin
           item := Pilots[i].start;
           anarray := Pilots[i].Fixes;
-          left:=0;
-          right:=length(anarray) - 1;
-          if ((item < anarray[left]) or (item > anarray[right])) then // prvek mimo rozsah
+          Vleft:=0;
+          Vright:=length(anarray) - 1;
+          if ((item < anarray[Vleft]) or (item > anarray[Vright])) then // prvek mimo rozsah
           begin
-            result:=-1;
+            Vresult:=-1;
             Info1 := 'element out of scope item = ' + IntToStr(item);
             exit;
           end;
-          while (left <= right) do begin // if we have something to share
-            center:=(left + right) div 2;
+          while (Vleft <= Vright) do begin // if we have something to share
+            center:=(Vleft + Vright) div 2;
             if (item = anarray[center].Tsec) then
               begin
                 PilotStartAlt := anarray[center].AltQnh;
                 PilotStartSpeed := anarray[center].Gsp;
-                result:=center; // found
+                Vresult:=center; // found
                 Break; // Ending the loop while
             end
             else
             if (item < anarray[center].Tsec) then
-              right:=center - 1 // throw away the right half
+              Vright:=center - 1 // throw away the Vright half
             else
-              left:=center + 1; // discard the left half
+              Vleft:=center + 1; // discard the Vleft half
               if (item < anarray[center+1].Tsec) then
                 begin
                   PilotStartAlt := (anarray[center].AltQnh + anarray[center+1].AltQnh) div 2;
                   PilotStartSpeed := (anarray[center].Gsp + anarray[center+1].Gsp;) div 2
-                  result:=center; // found
+                  Vresult:=center; // found
                   Break; // Ending the loop while
                 end;
 
             end;
-          result:=-1;
+          Vresult:=-1;
         end;
-        If result = -1 then
+        If Vresult = -1 then
           begin
             Info1 := 'Start not found!';
             exit;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -290,42 +290,53 @@ begin
 		           PilotStartSpeedSum := PilotStartSpeedSum + Pilots[i].Fixes[j].Gsp;
 		           PilotStartSpeedFixes := PilotStartSpeedFixes + 1;
                PilotStartAltSum := PilotStartAltSum + Pilots[i].Fixes[j].AltQnh;
+               if Pilots[i].fixes[j].Tsec = Pilots[i].start then
+               begin
+                 PilotStartSpeedSum := Pilots[i].Fixes[j].Gsp;
+		             PilotStartSpeedFixes := 0;
+                 PilotStartAltSum := Pilots[i].Fixes[j].AltQnh;
+                 break; // end the for j := loop
+               end;
 	           end;
            if (Pilots[i].Fixes[j].Tsec > Pilots[i].start+10)  then break; // end the for j := loop
 	       end;
 
        if PilotStartSpeedfixes>0 then 
        begin
-         PilotStartSpeed := PilotStartSpeedSum / PilotStartSpeedFixes;
-         PilotStartAlt := PilotStartAltSum / PilotStartSpeedFixes;
+         PilotStartSpeed := Int(PilotStartSpeedSum / PilotStartSpeedFixes);
+         PilotStartAlt := Int(PilotStartAltSum / PilotStartSpeedFixes);
        end;
       end;
     
-    DStSpd := 0;
-    DPStAlt := 0;
-    DFinishIsBelowSt := 0;
+     DStSpd := 0;
+     DPStAlt := 0;
+     DFinishIsBelowSt := 0;
 	   
-		DStSpd := PilotStartSpeed - MaxStSpd;
-		DPStAlt := PilotStartAlt - MaxStAlt;.war
-    DFinishIsBelowSt := MaxFinishIsBelowSt - (PilotStartAlt - Pilots[i].finishAlt);
+		 DStSpd := PilotStartSpeed - MaxStSpd;
+		 DPStAlt := PilotStartAlt - MaxStAlt;
+     DFinishIsBelowSt := MaxFinishIsBelowSt - (PilotStartAlt - Pilots[i].finishAlt);
            
-    if DStSpd > 0 then
-      begin
-        Pilots[i].finish := Pilots[i].finish + Int(DStspd * PStSpd);
-        Pilots[i].Warning := Pilots[i].Warning  + ' DStSpd = ' + IntToStr(Int(DStSpd));
-      end;
+     if DStSpd > 0 then
+       begin
+         Pilots[i].finish := Pilots[i].finish + DStspd * PStSpd;
+         Pilots[i].Warning := Pilots[i].Warning  + ' DStSpd = ' + IntToStr(DStSpd);
+       end;
     
-    if DPStAlt > 0 then
-      begin
-        Pilots[i].finish := Pilots[i].finish + Int(DPStAlt * PStAlt);
-        Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + IntToStr(Int(DPStAlt));
-      end;
+     if DPStAlt > 0 then
+       begin
+         Pilots[i].finish := Pilots[i].finish + DPStAlt * PStAlt;
+         Pilots[i].Warning := Pilots[i].Warning  + ' DPStAlt = ' + IntToStr(DPStAlt);
+       end;
      
-    if DFinishIsBelowSt > 0 then
-      begin
-        Pilots[i].finish := Pilots[i].finish + Int(DFinishIsBelowSt * PFinishIsBelowSt);
-        Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + IntToStr(Int(DFinishIsBelowSt));
-      end;      
+     if DFinishIsBelowSt > 0 then
+       begin
+         Pilots[i].finish := Pilots[i].finish + Int(DFinishIsBelowSt * PFinishIsBelowSt);
+         Pilots[i].Warning := Pilots[i].Warning  + ' D Start-Finis alt. = ' + IntToStr(DFinishIsBelowSt);
+       end;   
+     
+     T0 := Pilots[i].finish - Pilots[i].start;
+     if (AAT = true) and (T0 < Task.TaskTime) Then T0 := Task.TaskTime;
+     Pilots[i].speed := Pilots[i].dis/T0;
     end;
 end;
 

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -270,9 +270,9 @@ begin
 // Correction of speed and flight time with penalty seconds
 if UsePenaltySeconds = 1 then
 begin
-  MaxStSpd := ReadDayTagParameter ('MAXSTSPD', 0) 
-  MaxStAlt := ReadDayTagParameter ('MaxStAlt', 0)
-  MaxFinishIsBelowSt := ReadDayTagParameter ('MAXFINISHISBELOWST', 0)
+  MaxStSpd := ReadDayTagParameter ('MAXSTSPD', 0); 
+  MaxStAlt := ReadDayTagParameter ('MaxStAlt', 0);
+  MaxFinishIsBelowSt := ReadDayTagParameter ('MAXFINISHISBELOWST', 0);
   for i:=0 to GetArrayLength(Pilots)-1 do
   begin
     DStSpd := 0;
@@ -286,7 +286,7 @@ begin
 		    begin
 		      DStSpd := Pilots[i].Fixes[j].Gsp - MaxStSpd;
 		      DPStAlt := Pilots[i].Fixes[j].AltQnh - MaxStAlt;
-          DFinishIsBelowSt := MaxFinishIsBelowSt -(Pilots[i].Fixes[j].AltQnh - Pilot[i].finishAlt)
+          DFinishIsBelowSt := MaxFinishIsBelowSt -(Pilots[i].Fixes[j].AltQnh - Pilot[i].finishAlt);
           break; // end the for j := loop
 	      end;
       end;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -306,7 +306,7 @@ begin
               begin
                 PilotStartAlt := Pilots[i].Fixes[center].AltQnh;
                 PilotStartSpeed := Pilots[i].Fixes[center].Gsp;
-                Vresult:=center; // found
+                Vresult:= 1; // found
                 Break; // Ending the loop while
             end
             else
@@ -318,18 +318,24 @@ begin
                 begin
                   PilotStartAlt := (Pilots[i].Fixes[center].AltQnh + Pilots[i].Fixes[center+1].AltQnh) / 2;
                   PilotStartSpeed := (Pilots[i].Fixes[center].Gsp + Pilots[i].Fixes[center+1].Gsp) / 2;
-                  Vresult:=center; // found
+                  Vresult:= 2; // found
                   Break; // Ending the loop while
                 end;
 
             end;
-          Vresult:=-1;
         end;
-        If Vresult = -1 then
+        If Vresult = 0 then
           begin
-            Info1 := 'Start not found! Vresult = -1';
-            exit;
+            Pilots[i].Warning := Pilots[i].Warning  + #13 + 'Start not found! Vresult = 0' + ' CN = ' + Pilots[i].CompID;
           end;  
+        If Vresult = 1 then
+         begin
+           Pilots[i].Warning := Pilots[i].Warning  + #13 + 'Start found!' + ' CN = ' + Pilots[i].CompID;
+         end;  
+        If Vresult = 2 then
+         begin
+           Pilots[i].Warning := Pilots[i].Warning  + #13 + 'Start not found! Calculated average values from the fix before and after the start.' + ' CN = ' + Pilots[i].CompID;
+         end;  
         // binary searches End
     
      DStSpd := 0;

--- a/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
+++ b/igc_annex_a/AnnexA_scoring_Alternative_scoring.pas
@@ -306,7 +306,8 @@ begin
            PilotStartSpeed := (Pilots[i].Fixes[HHF].Gsp + Pilots[i].Fixes[HHF+1].Gsp)/2;
           end 
           else
-           HHF := Trunc(3*HHF / 2);
+           HHF := CountFixes + HHF;
+           if Trunc(HHF/2) > CountFixes-1 then StartFixFound := false;
           end;  
          if HHF < 3 then StartFixFound := false;     
         end;


### PR DESCRIPTION
### **Read Me - Alternative scoring with penalty seconds**
Final debugged version 12/30/2022
The script "IGC_Annex_A_scoring_2023_with_penalty" enables the scoring of gliding competitions according to the calculation formula published in the document "Alternative Scoring - Gliding" dated February 7, 2022.
https://www.fai.org/sites/default/files/altscoring.pdf
Without entering parameters in the window "Properties of the competition day" - line Pilots[i].Tag checks the flights in the usual way. In the Results, for the purpose of continuous calculation control, the display of Sp0, Spm and k parameters has been added.
Sp0 – Highest Provisional Score (SP) of the Day
Spm – Median Provisional Score (SP) of the Day, excluding competitors with SP = 0.
k – number of competitors whose scores were used to calculate Spm. The number of competitors whose score is not equal to 0.
### **PEV**
After entering the PEVWaitTime parameters, PEVStartWindow checks the correctness of the departure performed according to paragraph 7.4.2 b The PEV start stated in document Annex A to Section 3 – Gliding.
https://www.fai.org/sites/default/files/sc3a_2022.pdf
The number of PEV starts in the program is limited to 3. The program ignores further pressing of the PEV marker within 30 seconds. This time can be set in the constants of program.
PevStartTimeBuffer = 30;
If "AllUserWrng" in "DayTag" is set to 0, it will only display a start-message in the pilot warnings in case of a wrong start. When set to 1, it will display all and correct departures as well.
### **Interpolation of starting speed according to DAEC SWO 7.3.5**
Enter "MaxStSpd2=130" in DayTag to get interpolation and user alerts if average initial speed is greater than 130 km/h
### **Penalty seconds**
The program can evaluate the start altitude, start groundspeed and height difference between start and arrival and the exceedance of these values will be rated with seconds added to the competitor's flight time. It will then reduce the speed of the competitor. Vo, T0 parameters for scoring are calculated only after these corrections.
This should allow the organizer to set the start altitude, for example, 300 m below the predicted altitude of the cloud bases and to set the preferred altitude on arrival. The aim is to increase safety before start and upon arrival.
The parameter settings are displayed in the results for review.
The output of the evaluation is in the pilot's warning window. I assume copying the output to the "Comments" window so that it can be seen in the results.
The following penalty values are set in the constants of program (values can be changed):
GPS ground speed - 5 seconds per 1 km/h (taken from GP).
Altitude AMSL - 2 seconds per 1 m (taken from GP).
https://www.fai.org/sites/default/files/sgp-rules-v9.1_0.pdf
Loss of height - 1 second per 1 m. (Taken from CPS. 6.3.6 https://sk.gcup.eu/public/docs/rules/gcup_20150121_en.pdf)
_**Example:**_
_Entry into daily parameters_
PEVWaitTime=5 PEVStartWindow=8 MaxStSpd=170 MaxStAlt=1900 MaxFinishIsBelowSt=1520
_Output warning_
Start speed higher by 18.15 km/h, penalty seconds = 91; Start height exceeded by 260 m, penalty seconds = 520; Altitude loss between departure and arrival exceeded by 238 m penalty seconds = 238; Time added to the flight 00:14:09;
### Other
Other program options were preserved from the original script IGC_Annex_A_scoring_2021, of which this script is a modification. They are described in the initial header of the script.
